### PR TITLE
remove unsupported jQuery.support.opacity

### DIFF
--- a/jquery.spotlight.js
+++ b/jquery.spotlight.js
@@ -144,17 +144,14 @@
         fillOverlay();
 
         // Fade in the spotlight
-        if (settings.animate && jQuery.support.opacity) {
+        if (settings.animate) {
             overlay.animate({opacity: settings.opacity}, settings.speed, settings.easing, function () {
                 // Trigger the onShow callback
                 settings.onShow.call(this);
             });
         } else {
-            if (jQuery.support.opacity) {
-                overlay.css('opacity', settings.opacity);
-            } else {
-                overlay.css('filter', 'alpha(opacity=' + settings.opacity * 100 + ')');
-            }
+            overlay.css('opacity', settings.opacity);
+
             // Trigger the onShow callback
             settings.onShow.call(this);
         }


### PR DESCRIPTION
This property no longer exists in jQuery 2.0 and has been deprecated. Opacity will only work in IE9+.
